### PR TITLE
Upgrade base images

### DIFF
--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -7,7 +7,7 @@ RUN useradd -r bitcoin
 ENV GOSU_VERSION=1.9
 
 RUN apt-get update -y \
-  && apt-get install -y curl \
+  && apt-get install -y curl gnupg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/0.11/alpine/Dockerfile
+++ b/0.11/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -63,6 +63,7 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     boost-program_options \
     libevent \
     libzmq \
+    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -7,7 +7,7 @@ RUN useradd -r bitcoin
 ENV GOSU_VERSION=1.9
 
 RUN apt-get update -y \
-  && apt-get install -y curl \
+  && apt-get install -y curl gnupg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/0.12/alpine/Dockerfile
+++ b/0.12/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -63,6 +63,7 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     boost-program_options \
     libevent \
     libzmq \
+    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.13/Dockerfile
+++ b/0.13/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -7,7 +7,7 @@ RUN useradd -r bitcoin
 ENV GOSU_VERSION=1.9
 
 RUN apt-get update -y \
-  && apt-get install -y curl \
+  && apt-get install -y curl gnupg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/0.13/alpine/Dockerfile
+++ b/0.13/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -63,6 +63,7 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     boost-program_options \
     libevent \
     libzmq \
+    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.14/Dockerfile
+++ b/0.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -7,7 +7,7 @@ RUN useradd -r bitcoin
 ENV GOSU_VERSION=1.9
 
 RUN apt-get update -y \
-  && apt-get install -y curl \
+  && apt-get install -y curl gnupg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/0.14/alpine/Dockerfile
+++ b/0.14/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 MAINTAINER Rui Marinho <rui.marinho@seegno.com> (@ruimarinho)
 
@@ -63,6 +63,7 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     boost-program_options \
     libevent \
     libzmq \
+    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]


### PR DESCRIPTION
Highlight to the new `debian:stretch-slim` images which significantly reduces the image size for the Debian variant.