### PR TITLE
Switch from openssl to libressl

### DIFF
--- a/0.12/alpine/Dockerfile
+++ b/0.12/alpine/Dockerfile
@@ -20,10 +20,10 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     file \
     gnupg \
     libevent-dev \
+    libressl \
+    libressl-dev \
     libtool \
     linux-headers \
-    openssl \
-    openssl-dev \
     protobuf-dev \
     zeromq-dev \
   && mkdir -p /tmp/build \
@@ -62,8 +62,8 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
   && apk --no-cache add boost \
     boost-program_options \
     libevent \
+    libressl \
     libzmq \
-    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.13/alpine/Dockerfile
+++ b/0.13/alpine/Dockerfile
@@ -20,10 +20,10 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     file \
     gnupg \
     libevent-dev \
+    libressl \
+    libressl-dev \
     libtool \
     linux-headers \
-    openssl \
-    openssl-dev \
     protobuf-dev \
     zeromq-dev \
   && mkdir -p /tmp/build \
@@ -62,8 +62,8 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
   && apk --no-cache add boost \
     boost-program_options \
     libevent \
+    libressl \
     libzmq \
-    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.14/alpine/Dockerfile
+++ b/0.14/alpine/Dockerfile
@@ -20,10 +20,10 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     file \
     gnupg \
     libevent-dev \
+    libressl \
+    libressl-dev \
     libtool \
     linux-headers \
-    openssl \
-    openssl-dev \
     protobuf-dev \
     zeromq-dev \
   && mkdir -p /tmp/build \
@@ -62,8 +62,8 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
   && apk --no-cache add boost \
     boost-program_options \
     libevent \
+    libressl \
     libzmq \
-    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.15/alpine/Dockerfile
+++ b/0.15/alpine/Dockerfile
@@ -21,10 +21,10 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
     file \
     gnupg \
     libevent-dev \
+    libressl \
+    libressl-dev \
     libtool \
     linux-headers \
-    openssl \
-    openssl-dev \
     protobuf-dev \
     zeromq-dev \
   && mkdir -p /tmp/build \
@@ -63,8 +63,8 @@ RUN apk --no-cache --virtual build-dependendencies add autoconf \
   && apk --no-cache add boost \
     boost-program_options \
     libevent \
+    libressl \
     libzmq \
-    openssl \
     su-exec
 
 VOLUME ["/home/bitcoin/.bitcoin"]


### PR DESCRIPTION
From 0.12+ LibreSSL is supported. With alpine 3.6 we can finally do the switch.