### PR TITLE
Bug in GPG: argument --batch needed to build Dockerfile

### DIFF
--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -13,6 +13,7 @@ RUN useradd -r bitcoin \
   && for key in \
     B42F6819007F00F88E364FD4036A9C25BF357DD4 \
   ; do \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
     gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
     gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
     gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -23,7 +23,7 @@ ENV GOSU_VERSION=1.10
 
 RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
   && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
-  && gpg --batch --verify /usr/local/bin/gosu.asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
 

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -23,7 +23,7 @@ ENV GOSU_VERSION=1.10
 
 RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
   && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
-  && gpg --verify /usr/local/bin/gosu.asc \
+  && gpg --batch --verify /usr/local/bin/gosu.asc \
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
 

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -13,10 +13,10 @@ RUN useradd -r bitcoin \
   && for key in \
     B42F6819007F00F88E364FD4036A9C25BF357DD4 \
   ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
   done
 
 ENV GOSU_VERSION=1.10

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -31,10 +31,10 @@ ENV BITCOIN_VERSION=0.17.0
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 
-RUN curl -SL https://bitcoin.org/laanwj-releases.asc | gpg --import \
+RUN curl -SL https://bitcoin.org/laanwj-releases.asc | gpg --batch --import \
   && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
   && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
-  && gpg --verify SHA256SUMS.asc \
+  && gpg --batch --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \
   && rm *.tar.gz *.asc


### PR DESCRIPTION
There's currently a bug in GPG that breaks the Docker build process of your Dockerfiles. GPG encounters an error if there is no TTY present (such as during the `docker build`) and exits with error code 2.

The bug seems to be a non-trivial one, see the following acknoledgement:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=913614#27

From the comment, there's this paragraph, which also provides the solution: by using the argument `--batch` GPG assumes a non-interactive environment and gets the keys without issues.

> PS i do encourage everyone who is automating the use of gpg to use
> --batch everywhere, as this forces GnuPG into a mode that is expected to
> be used for automation (its "API", for lack of a better term, as opposed
> to its "UI", which is its normal non-batch mode). And, FWIW, i agree
> with Tianon that GnuPG should simply assume --batch if no tty exists,
> but that's not the kind of change i can fit into debian stable, i think.

I just added the `--batch` argument on the latest Dockerfile (v0.17.0), but it may be worthwile to extend this to other versions as well.