### PR TITLE
Fix: remove latest from 0.17 version from Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A bitcoin-core docker image.
 - `0.18.0`, `0.18`, `latest` ([0.18/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.18/Dockerfile))
 - `0.18.0-alpine`, `0.18-alpine` ([0.18/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.18/alpine/Dockerfile))
 
-- `0.17.1`, `0.17`, `latest` ([0.17/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.17/Dockerfile))
+- `0.17.1`, `0.17` ([0.17/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.17/Dockerfile))
 - `0.17.1-alpine`, `0.17-alpine` ([0.17/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.17/alpine/Dockerfile))
 
 - `0.16.3`, `0.16` ([0.16/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.16/Dockerfile))


### PR DESCRIPTION
This was discovered in #78, there are 2 latest versions (0.18 and 0.17).

Just to make sure, I ran `docker run ruimarinho/bitcoin-core --version` and the text `Bitcoin Core Daemon version v0.18.0` was printed.

So it's just a documentation issue on the readme file.