### PR TITLE
fix: Example for Exposing Ports needs -rpcbind

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ docker run --rm -it \
   -printtoconsole \
   -regtest=1 \
   -rpcallowip=172.17.0.0/16 \
+  -rpcbind=0.0.0.0 \
   -rpcauth='foo:7d9ba5ae63c3d4dc30583ff4fe65a67e$9e3634e81c11659e3de036d0bf88f89cd169c1039e6e09607562d54765c649cc'
 ```
 


### PR DESCRIPTION
The example in the README section [Exposing Ports](https://github.com/ruimarinho/docker-bitcoin-core#exposing-ports) is out dated. The [release notes](https://bitcoin.org/en/release/v0.18.0#configuration-option-changes) for Bitcoin Core v0.18.0 state:

> The `rpcallowip` option can no longer be used to automatically listen on all network interfaces. Instead, the `rpcbind` parameter must be used to specify the IP addresses to listen on. [...]

This PR adds `-rpcbind=0.0.0.0` to bind on all interfaces of the container in the example. 