### PR TITLE
add bitcoin core version 0.19.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_script:
   - IMAGE="bitcoin-core:${VERSION/\//-}"
 
 env:
+  - VERSION=0.19
+  - VERSION=0.19/alpine
   - VERSION=0.18
   - VERSION=0.18/alpine
   - VERSION=0.17

--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:stable-slim
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN useradd -r bitcoin \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg gosu \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV BITCOIN_VERSION=0.19.0.1
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN set -ex \
+  && for key in \
+    01EA5486DE18A882D4C2684590C8019E36C2E964 \
+  ; do \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+      gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+      gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+    done \
+  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && gpg --verify SHA256SUMS.asc \
+  && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
+  && tar -xzf *.tar.gz -C /opt \
+  && rm *.tar.gz *.asc
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["bitcoind"]

--- a/0.19/alpine/Dockerfile
+++ b/0.19/alpine/Dockerfile
@@ -1,0 +1,120 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add libressl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Bitcoin Core
+FROM alpine as bitcoin-core
+
+COPY --from=berkeleydb /opt /opt
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add boost-dev
+RUN apk --no-cache add build-base
+RUN apk --no-cache add chrpath
+RUN apk --no-cache add file
+RUN apk --no-cache add gnupg
+RUN apk --no-cache add libevent-dev
+RUN apk --no-cache add libressl
+RUN apk --no-cache add libressl-dev
+RUN apk --no-cache add libtool
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add protobuf-dev
+RUN apk --no-cache add zeromq-dev
+RUN set -ex \
+  && for key in \
+    90C8019E36C2E964 \
+  ; do \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
+
+ENV BITCOIN_VERSION=0.19.0.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+
+RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN gpg --verify SHA256SUMS.asc
+RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
+RUN tar -xzf *.tar.gz
+
+WORKDIR /bitcoin-${BITCOIN_VERSION}
+
+RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
+RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
+RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
+RUN ./autogen.sh
+RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+    --prefix=${BITCOIN_PREFIX} \
+    --mandir=/usr/share/man \
+    --disable-tests \
+    --disable-bench \
+    --disable-ccache \
+    --with-gui=no \
+    --with-utils \
+    --with-libs \
+    --with-daemon
+RUN make -j4
+RUN make install
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
+
+# Build stage for compiled artifacts
+FROM alpine
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN adduser -S bitcoin
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add \
+  boost \
+  boost-program_options \
+  libevent \
+  libressl \
+  libzmq \
+  su-exec
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=0.19.0.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+
+COPY --from=bitcoin-core /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["bitcoind"]

--- a/0.19/alpine/docker-entrypoint.sh
+++ b/0.19/alpine/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  chown -R bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec su-exec bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/0.19/docker-entrypoint.sh
+++ b/0.19/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  chown -R bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec gosu bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ A bitcoin-core docker image.
 
 ## Tags
 
-- `0.18.1`, `0.18`, `latest` ([0.18/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.18/Dockerfile))
+- `0.19.0.1`, `0.19`, `latest` ([0.19/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/Dockerfile))
+- `0.19.0.1-alpine`, `0.19-alpine` ([0.19/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/alpine/Dockerfile))
+
+- `0.18.1`, `0.18`, ([0.18/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.18/Dockerfile))
 - `0.18.1-alpine`, `0.18-alpine` ([0.18/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.18/alpine/Dockerfile))
 
 - `0.17.1`, `0.17` ([0.17/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.17/Dockerfile))


### PR DESCRIPTION
In This PR we add support for bitcoin core version 0.19.0.1.

I just duplicated the 0.18 folder to a 0.19 folder, and replaced any version `0.18` with `0.19.0.1`. I have no idea if this is all that needs to be done, but at least it's a starting point.

Fixes #88 