### PR TITLE
Restructured 0.19 Debian build to support ARM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,6 @@ language: bash
 script:
   - docker build -t "$IMAGE" .
   - docker run "$IMAGE" --version | grep "Bitcoin Core"
+  - docker build -t "$IMAGE-arm64v8" --build-arg ARCH=arm64v8 .
 
 services: docker

--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stable-slim
+ARG ARCH=amd64
+FROM debian:stable-slim as build
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
@@ -6,15 +7,14 @@ LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
 
 RUN useradd -r bitcoin \
   && apt-get update -y \
-  && apt-get install -y curl gnupg gosu \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  && apt-get install -y curl gnupg
 
+ARG ARCH
 ENV BITCOIN_VERSION=0.19.0.1
-ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 
 RUN set -ex \
+  && if [ "${ARCH}" = "amd64" ]; then export ARCH=x86_64; fi \
+  && if [ "${ARCH}" = "arm64v8" ]; then export ARCH=aarch64; fi \
   && for key in \
     01EA5486DE18A882D4C2684590C8019E36C2E964 \
   ; do \
@@ -25,12 +25,25 @@ RUN set -ex \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
   && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${ARCH}-linux-gnu.tar.gz \
   && gpg --verify SHA256SUMS.asc \
-  && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
+  && grep " bitcoin-${BITCOIN_VERSION}-${ARCH}-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc
+  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt \
+  && mv /opt/bitcoin-${BITCOIN_VERSION}/bin/* /usr/local/bin \
+  && mv /opt/bitcoin-${BITCOIN_VERSION}/lib/* /usr/local/lib \
+  && mkdir -p /home/bitcoin/.bitcoin
 
+FROM $ARCH/debian:stable-slim
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+COPY --from=build /usr/local /usr/local
+COPY --from=build --chown=bitcoin:bitcoin /home/bitcoin /home/bitcoin
+
+USER bitcoin:bitcoin
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]

--- a/0.19/docker-entrypoint.sh
+++ b/0.19/docker-entrypoint.sh
@@ -9,8 +9,6 @@ fi
 
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
-  chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 
@@ -19,7 +17,7 @@ fi
 
 if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
   echo
-  exec gosu bitcoin "$@"
+  exec "$@"
 fi
 
 echo


### PR DESCRIPTION
Closes #67

Restructured 0.19 Debian build on way that last stage does not need **RUN** instructions so it can create ARM image(s) without need to use emulator.

Also dropped bitcoin-qt binary as it doen't work on Docker and only cause unnecessary overhead.

Tested with Raspberry PI 3b+ and Rancher OS 1.5.4 that those images really can run on ARM.