### PR TITLE
Add experimental multiarch support for debian variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,87 @@
+before_install:
+  - curl -sf https://test.docker.com | sh
+  - docker --version
+
+dist: bionic
+
 after_script:
-  - docker images
 
 before_script:
-  - cd "$VERSION"
-  - IMAGE="bitcoin-core:${VERSION/\//-}"
+  - LATEST_BITCOIN_VERSION=$(ls  | grep 0 | sort -n | tail -n 1)
 
 env:
-  - VERSION=0.19
-  - VERSION=0.19/alpine
-  - VERSION=0.18
-  - VERSION=0.18/alpine
-  - VERSION=0.17
-  - VERSION=0.17/alpine
-  - VERSION=0.16
-  - VERSION=0.16/alpine
-  - VERSION=0.13
-  - VERSION=0.13/alpine
-  - VERSION=0.12
-  - VERSION=0.12/alpine
-  - VERSION=0.11
-  - VERSION=0.11/alpine
+  global:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64
+  matrix:
+    - BITCOIN_VERSION=0.19
+    - BITCOIN_VERSION=0.19/alpine
+    - BITCOIN_VERSION=0.18
+    - BITCOIN_VERSION=0.18/alpine
+    - BITCOIN_VERSION=0.17
+    - BITCOIN_VERSION=0.17/alpine
+    - BITCOIN_VERSION=0.16
+    - BITCOIN_VERSION=0.16/alpine
+    - BITCOIN_VERSION=0.13
+    - BITCOIN_VERSION=0.13/alpine
+    - BITCOIN_VERSION=0.12
+    - BITCOIN_VERSION=0.12/alpine
+    - BITCOIN_VERSION=0.11
+    - BITCOIN_VERSION=0.11/alpine
 
-language: bash
+language: shell
 
 script:
-  - docker build -t "$IMAGE" .
-  - docker run "$IMAGE" --version | grep "Bitcoin Core"
+  - |
+    PUSH=false
+    REPO=ruimarinho/bitcoin-core
+    BUILD_IMAGE_TAG=$REPO:${BITCOIN_VERSION/\//-}
+    LATEST_IMAGE_TAG=$REPO:latest
 
-services: docker
+    if [ -n "$TRAVIS_TAG" ]; then
+      BUILD_IMAGE_TAG=ruimarinho/bitcoin-core:$TRAVIS_TAG
+    fi
+
+    echo ">>> Docker repo set to $REPO"
+    echo ">>> Docker build image set to $BUILD_IMAGE_TAG"
+    echo ">>> Docker latest image set to $LATEST_IMAGE_TAG"
+    echo ">>> Latest bitcoin version found was $LATEST_BITCOIN_VERSION"
+
+    # Push if git tag is not present, we are on the master branch and the build matches the latest version available.
+    if [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$BITCOIN_VERSION" == "$LATEST_BITCOIN_VERSION" ]; then
+      PUSH=true
+      echo ">>> Docker image $BUILD_IMAGE_TAG will be pushed to registry along with $LATEST_IMAGE_TAG"
+    fi
+
+    function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+    # Login to Docker Hub if image will be pushed.
+    if [ "$PUSH" = true ]; then
+      echo "$DOCKER_HUB_PASSWORD" | docker login -u ruimarinho --password-stdin
+    fi
+
+    if [ $(version $BITCOIN_VERSION) -ge $(version "0.19") ] && [[ ${BITCOIN_VERSION} != *"alpine"* ]]; then
+        echo ">>> Using docker buildx"
+
+        docker run --privileged linuxkit/binfmt:v0.8
+        docker buildx create --use
+        docker buildx build \
+          --platform "$PLATFORMS" \
+          --tag "$BUILD_IMAGE_TAG" \
+          `if [ "$PUSH" = true ]; then echo "--tag $LATEST_IMAGE_TAG"; fi` \
+          $BITCOIN_VERSION \
+          `if [ "$PUSH" = true ]; then echo "--push"; fi`
+
+        docker buildx imagetools inspect "$BUILD_IMAGE_TAG"
+    else
+      echo ">>> Using docker build"
+
+      docker build --tag "$BUILD_IMAGE_TAG" $BITCOIN_VERSION
+
+      if [ "$PUSH" = true ]; then
+        docker push "$BUILD_IMAGE_TAG"
+      fi
+
+      docker inspect "$BUILD_IMAGE_TAG"
+    fi
+

--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
@@ -10,11 +10,15 @@ RUN useradd -r bitcoin \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ARG TARGETPLATFORM
 ENV BITCOIN_VERSION=0.19.1
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 
 RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
   && for key in \
     01EA5486DE18A882D4C2684590C8019E36C2E964 \
   ; do \
@@ -24,12 +28,13 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
+  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
   && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && gpg --verify SHA256SUMS.asc \
-  && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
+  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc
+  && rm *.tar.gz *.asc \
+  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # ruimarinho/bitcoin-core
 
-A bitcoin-core docker image.
+A bitcoin-core docker image with support for the following platforms:
+
+* `amd64` (x86_64)
+* `arm32v7` (armv7)
+* `arm64` (aarch64, armv8)
 
 [![ruimarinho/bitcoin-core][docker-pulls-image]][docker-hub-url] [![ruimarinho/bitcoin-core][docker-stars-image]][docker-hub-url] [![ruimarinho/bitcoin-core][docker-size-image]][docker-hub-url] [![ruimarinho/bitcoin-core][docker-layers-image]][docker-hub-url]
 
 ## Tags
 
-- `0.19.1`, `0.19`, `latest` ([0.19/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/Dockerfile))
+- `0.19.1`, `0.19`, `latest` ([0.19/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/Dockerfile)) [**multi-arch**]
 - `0.19.1-alpine`, `0.19-alpine` ([0.19/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/alpine/Dockerfile))
 
 - `0.18.1`, `0.18`, ([0.18/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.18/Dockerfile))
@@ -20,6 +24,10 @@ A bitcoin-core docker image.
 
 - `0.15.1`, `0.15` ([0.15/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.15/Dockerfile))
 - `0.15.1-alpine`, `0.15-alpine` ([0.15/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.15/alpine/Dockerfile))
+
+**Multi-architecture builds**
+
+The newest images (Debian-based, *0.19+*) provide built-in support for multiple architectures. Running `docker pull` on any of the supported platforms will automatically choose the right image for you as all of the manifests and artifacts are pushed to the Docker registry.
 
 **Picking the right tag**
 


### PR DESCRIPTION
A follow up to https://github.com/ruimarinho/docker-bitcoin-core/pull/90 based on `docker buildx` with support for the following architectures on the Debian-based variant of 0.19+ images:

* `amd64` (x86_64)
* `arm32v7` (armv7)
* `arm64` (aarch64, armv8)

Completely disabled the completely broken Docker Hub / Docker Cloud integration as its simply too slow and unreliable. Next step is removing the semi-broken Travis and replacing it by Github Action.

The path to supporting additional images (going back to 0.13) and even on the alpine-based variant (see https://github.com/bitcoin/bitcoin/blob/a5623ba89f050182ce9b1f570f3736b272b544b2/depends/README.md#for-linux-including-i386-arm-cross-compilation for details). Right now I don't have enough time to explore this, but PRs are welcome.

Any feedback would be greatly appreciated. I might boot my HypriotOS-based RPi3B+ during the weekend to give this a proper test on real hardware.