### PR TITLE
0.19 Alpine: Install less build and runtime packages

### DIFF
--- a/0.19/alpine/Dockerfile
+++ b/0.19/alpine/Dockerfile
@@ -40,7 +40,6 @@ RUN apk --no-cache add libressl
 RUN apk --no-cache add libressl-dev
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
-RUN apk --no-cache add protobuf-dev
 RUN apk --no-cache add zeromq-dev
 RUN set -ex \
   && for key in \

--- a/0.19/alpine/Dockerfile
+++ b/0.19/alpine/Dockerfile
@@ -95,8 +95,10 @@ LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
 RUN adduser -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
-  boost \
-  boost-program_options \
+  boost-chrono \
+  boost-filesystem \
+  boost-system \
+  boost-thread \
   libevent \
   libressl \
   libzmq \


### PR DESCRIPTION
https://github.com/ruimarinho/docker-bitcoin-core/commit/203c717d9ec54f4c7b65e3848ddb36a98d169b98: 
Protobuf is not required if the GUI is not being built.

https://github.com/ruimarinho/docker-bitcoin-core/commit/ddfb172210e5bd0e2a2dbca1ad6bac7d1563e114:
Even though boost-dev is still required for building, (due to a issue
I'm pretty sure we've fixed for 0.20), you can get away with just
installing the needed libraries for runtime. 
Boost Program Options is also no-longer required.