### PR TITLE
Add Bitcoin Core 0.20.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - PLATFORMS=linux/amd64,linux/arm/v7,linux/arm64
   matrix:
+    - BITCOIN_VERSION=0.20
+    - BITCOIN_VERSION=0.20/alpine
     - BITCOIN_VERSION=0.19
     - BITCOIN_VERSION=0.19/alpine
     - BITCOIN_VERSION=0.18

--- a/0.20/Dockerfile
+++ b/0.20/Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -r bitcoin \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
-ENV BITCOIN_VERSION=0.20.0
+ENV BITCOIN_VERSION=0.20.1
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 

--- a/0.20/alpine/Dockerfile
+++ b/0.20/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex \
     gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
   done
 
-ENV BITCOIN_VERSION=0.20.0
+ENV BITCOIN_VERSION=0.20.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
 RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
@@ -102,7 +102,7 @@ RUN apk --no-cache add \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV BITCOIN_VERSION=0.20.0
+ENV BITCOIN_VERSION=0.20.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A bitcoin-core docker image with support for the following platforms:
 
 ## Tags
 
-- `0.20.0`, `0.20`, `latest` ([0.20/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.20/Dockerfile)) [**multi-arch**]
-- `0.20.0-alpine`, `0.20-alpine` ([0.20/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.20/alpine/Dockerfile))
+- `0.20.1`, `0.20`, `latest` ([0.20/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.20/Dockerfile)) [**multi-arch**]
+- `0.20.1-alpine`, `0.20-alpine` ([0.20/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.20/alpine/Dockerfile))
 
 - `0.19.1`, `0.19` ([0.20/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/Dockerfile)) [**multi-arch**]
 - `0.19.1-alpine`, `0.19-alpine` ([0.19/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.19/alpine/Dockerfile))


### PR DESCRIPTION
Fixes #101.
Updates the `0.20` line to `0.20.1` and adds builds for `0.20` to Travis as well.