### PR TITLE
Added a small networking caveat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ bitcoin-core:
   command:
     -printtoconsole
     -regtest=1
+    -server=1
+    -rpcbind=127.0.0.1
+    -rpcallowip=0.0.0.0/0
 ```
+
+Docker on Linux only supports IPv6, therefore to enable IPv4 use the `rpcbind` option. 
 
 ### Using RPC to interact with the daemon
 


### PR DESCRIPTION
#115 

I think most people using docker compose will want the rpc functionality compose a service (lightning, coinjoin, etc) so the example should include it.

Would you welcome a minimal c-lightning example?