### PR TITLE
Add support for custom uid gid

### DIFF
--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:stable-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.11/alpine/Dockerfile
+++ b/0.11/alpine/Dockerfile
@@ -99,7 +99,8 @@ LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost \
@@ -107,6 +108,7 @@ RUN apk --no-cache add \
   libevent \
   openssl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.11/alpine/docker-entrypoint.sh
+++ b/0.11/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.11/docker-entrypoint.sh
+++ b/0.11/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:stable-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.12/alpine/Dockerfile
+++ b/0.12/alpine/Dockerfile
@@ -91,11 +91,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine:3.9
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost \
@@ -103,6 +107,7 @@ RUN apk --no-cache add \
   libevent \
   libressl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.12/alpine/docker-entrypoint.sh
+++ b/0.12/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.12/docker-entrypoint.sh
+++ b/0.12/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.13/Dockerfile
+++ b/0.13/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:stable-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.13/alpine/Dockerfile
+++ b/0.13/alpine/Dockerfile
@@ -91,11 +91,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine:3.9
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost \
@@ -103,6 +107,7 @@ RUN apk --no-cache add \
   libevent \
   libressl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.13/alpine/docker-entrypoint.sh
+++ b/0.13/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.13/docker-entrypoint.sh
+++ b/0.13/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:stable-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.16/alpine/Dockerfile
+++ b/0.16/alpine/Dockerfile
@@ -89,11 +89,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine:3.9
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost \
@@ -101,6 +105,7 @@ RUN apk --no-cache add \
   libevent \
   libressl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.16/alpine/docker-entrypoint.sh
+++ b/0.16/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.16/docker-entrypoint.sh
+++ b/0.16/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:stable-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.17/alpine/Dockerfile
+++ b/0.17/alpine/Dockerfile
@@ -89,11 +89,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine:3.9
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost \
@@ -101,6 +105,7 @@ RUN apk --no-cache add \
   libevent \
   libressl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.17/alpine/docker-entrypoint.sh
+++ b/0.17/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.17/docker-entrypoint.sh
+++ b/0.17/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.18/Dockerfile
+++ b/0.18/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:stable-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.18/alpine/Dockerfile
+++ b/0.18/alpine/Dockerfile
@@ -89,11 +89,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine:3.9
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost \
@@ -101,6 +105,7 @@ RUN apk --no-cache add \
   libevent \
   libressl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.18/alpine/docker-entrypoint.sh
+++ b/0.18/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.18/docker-entrypoint.sh
+++ b/0.18/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:bullseye-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.19/alpine/Dockerfile
+++ b/0.19/alpine/Dockerfile
@@ -85,14 +85,17 @@ RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 
-# Build stage for compiled artifacts
 FROM alpine
+
+ARG UID=101
+ARG GID=101
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost-chrono \
@@ -102,6 +105,7 @@ RUN apk --no-cache add \
   libevent \
   libressl \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.19/alpine/docker-entrypoint.sh
+++ b/0.19/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.19/docker-entrypoint.sh
+++ b/0.19/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.20/Dockerfile
+++ b/0.20/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:bullseye-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.20/alpine/Dockerfile
+++ b/0.20/alpine/Dockerfile
@@ -84,14 +84,17 @@ RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 
-# Build stage for compiled artifacts
 FROM alpine
+
+ARG UID=100
+ARG GID=101
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost-filesystem \
@@ -99,6 +102,7 @@ RUN apk --no-cache add \
   boost-thread \
   libevent \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.20/alpine/docker-entrypoint.sh
+++ b/0.20/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.20/docker-entrypoint.sh
+++ b/0.20/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -1,10 +1,13 @@
 FROM debian:bullseye-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN useradd --system --user-group bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/0.21/alpine/Dockerfile
+++ b/0.21/alpine/Dockerfile
@@ -86,14 +86,17 @@ RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 
-# Build stage for compiled artifacts
 FROM alpine
+
+ARG UID=100
+ARG GID=101
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup -S bitcoin
+RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost-filesystem \
@@ -102,6 +105,7 @@ RUN apk --no-cache add \
   sqlite-dev \
   libevent \
   libzmq \
+  shadow \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/0.21/alpine/docker-entrypoint.sh
+++ b/0.21/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/0.21/docker-entrypoint.sh
+++ b/0.21/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:bullseye-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -99,14 +99,17 @@ RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 
-# Build stage for compiled artifacts
 FROM alpine
+
+ARG UID=100
+ARG GID=101
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost-filesystem \
@@ -114,6 +117,7 @@ RUN apk --no-cache add \
   boost-thread \
   libevent \
   libzmq \
+  shadow \
   sqlite-dev \
   su-exec
 

--- a/22/alpine/docker-entrypoint.sh
+++ b/22/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/22/docker-entrypoint.sh
+++ b/22/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/23/Dockerfile
+++ b/23/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:bullseye-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/23/alpine/Dockerfile
+++ b/23/alpine/Dockerfile
@@ -1,6 +1,8 @@
 # Build stage for BerkeleyDB
 FROM alpine as berkeleydb
 
+ARG TARGETPLATFORM
+
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add autoconf
 RUN apk --no-cache add automake
@@ -106,11 +108,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost-filesystem \

--- a/23/alpine/docker-entrypoint.sh
+++ b/23/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/23/docker-entrypoint.sh
+++ b/23/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/24/Dockerfile
+++ b/24/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:bullseye-slim
 
+ARG UID=101
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN useradd -r bitcoin \
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
   && apt-get install -y curl gnupg gosu \
   && apt-get clean \

--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p ${BERKELEYDB_PREFIX}
 
 WORKDIR /${BERKELEYDB_VERSION}/build_unix
 
-RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
 RUN make -j4
 RUN make install
 RUN rm -rf ${BERKELEYDB_PREFIX}/docs
@@ -99,11 +99,15 @@ RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 # Build stage for compiled artifacts
 FROM alpine
 
+ARG UID=100
+ARG GID=101
+
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S bitcoin
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
   boost-filesystem \
@@ -111,6 +115,7 @@ RUN apk --no-cache add \
   boost-thread \
   libevent \
   libzmq \
+  shadow \
   sqlite-dev \
   su-exec
 

--- a/24/alpine/docker-entrypoint.sh
+++ b/24/alpine/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/24/docker-entrypoint.sh
+++ b/24/docker-entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
 
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
@@ -10,7 +20,10 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
   mkdir -p "$BITCOIN_DATA"
   chmod 700 "$BITCOIN_DATA"
-  chown -R bitcoin "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
 
   echo "$0: setting data directory to $BITCOIN_DATA"
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This image contains the main binaries from the Bitcoin Core project - `bitcoind`
 
 _Note: [learn more](#using-rpcauth-for-remote-authentication) about how `-rpcauth` works for remote authentication._
 
-By default, `bitcoind` will run as user `bitcoin` for security reasons and with its default data dir (`~/.bitcoin`). If you'd like to customize where `bitcoin-core` stores its data, you must use the `BITCOIN_DATA` environment variable. The directory will be automatically created with the correct permissions for the `bitcoin` user and `bitcoin-core` automatically configured to use it.
+By default, `bitcoind` will run as user `bitcoin` in the group `bitcoin` for security reasons and with its default data dir set to `~/.bitcoin`. If you'd like to customize where `bitcoin-core` stores its data, you must use the `BITCOIN_DATA` environment variable. The directory will be automatically created with the correct permissions for the `bitcoin` user and `bitcoind` automatically configured to use it.
 
 ```sh
 ❯ docker run --env BITCOIN_DATA=/var/lib/bitcoin-core --rm -it ruimarinho/bitcoin-core \
@@ -96,6 +96,20 @@ bitcoin-core:
     -printtoconsole
     -regtest=1
 ```
+
+### Using a custom user id (UID) and group id (GID)
+
+By default, images are created with a `bitcoin` user/group using a static UID/GID (`101:101` on Debian and `100:101` on Alpine). You may customize the user and group ids using the build arguments `UID` (`--build-arg UID=<uid>`) and `GID` (`--build-arg GID=<gid>`).
+
+If you'd like to use the pre-built images, uou can also customize the UID/GID on runtime via environment variables `$UID` and `$GID`:
+
+```sh
+❯ docker run -e UID=10000 -e GID=10000 -it --rm ruimarinho/bitcoin-core \
+  -printtoconsole \
+  -regtest=1
+```
+
+This will recursively change the ownership of the `bitcoin` home directory and `$BITCOIN_DATA` to UID/GID `10000:10000`.
 
 ### Using RPC to interact with the daemon
 


### PR DESCRIPTION
By default, images are created with a `bitcoin` user/group using a static UID/GID (`101:101` on Debian and `100:101` on Alpine). You may customize the user and group ids using the build arguments `$UID` (`--build-arg UID=<uid>`) and `$GID` (`--build-arg GID=<gid>`).

You can also customize the UID/GID on runtime, such as:

```sh
❯ docker run -e UID=10000 -e GID=10000 -it --rm ruimarinho/bitcoin-core \
  -printtoconsole \
  -regtest=1
```

This will recursively change the ownership of the `bitcoin` home directory and `$BITCOIN_DATA` to UID/GID `10000:10000`.