### PR TITLE
Compile sqlite to enable wallet descriptors

### DIFF
--- a/0.21/alpine/Dockerfile
+++ b/0.21/alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
 RUN set -ex \
   && for key in \
@@ -75,6 +76,7 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-gui=no \
     --with-utils \
     --with-libs \
+    --with-sqlite=yes \
     --with-daemon
 RUN make -j4
 RUN make install
@@ -97,6 +99,7 @@ RUN apk --no-cache add \
   boost-filesystem \
   boost-system \
   boost-thread \
+  sqlite-dev \
   libevent \
   libzmq \
   su-exec

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
 RUN set -ex \
   && for key in \
@@ -88,6 +89,7 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-gui=no \
     --with-utils \
     --with-libs \
+    --with-sqlite=yes \
     --with-daemon
 RUN make -j4
 RUN make install
@@ -112,6 +114,7 @@ RUN apk --no-cache add \
   boost-thread \
   libevent \
   libzmq \
+  sqlite-dev \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/23/alpine/Dockerfile
+++ b/23/alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
 RUN set -ex \
   && for key in \
@@ -92,6 +93,7 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-gui=no \
     --with-utils \
     --with-libs \
+    --with-sqlite=yes \
     --with-daemon
 RUN make -j4
 RUN make install
@@ -114,6 +116,7 @@ RUN apk --no-cache add \
   boost-filesystem \
   boost-system \
   boost-thread \
+  sqlite-dev \
   libevent \
   libzmq \
   su-exec


### PR DESCRIPTION
In version `>= 0.23` Descriptor wallets became the default type of wallet which were experimentally introduced in version `0.21` and only possible by passing `descriptors=true` to the `createwallet` call. This requires sqlite to be compiled, otherwise this error is thrown.
```
error code: -4
error message:
Compiled without sqlite support (required for descriptor wallets)
```
# References
- [release-notes-23.0](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.0.md#wallet)
- [Interesting read](https://achow101.com/2020/10/0.21-wallets#:~:text=Benefits%20of%20Descriptor%20Wallets,scripts%20necessary%20to%20sign%20them.)