### PR TITLE
23: Bump from 23.0 to 23.2

### DIFF
--- a/23/Dockerfile
+++ b/23/Dockerfile
@@ -15,7 +15,7 @@ RUN groupadd --gid ${GID} bitcoin \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
-ENV BITCOIN_VERSION=23.0
+ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 

--- a/23/alpine/Dockerfile
+++ b/23/alpine/Dockerfile
@@ -70,7 +70,7 @@ RUN set -ex \
   done && \
   wget -O- https://raw.githubusercontent.com/Kvaciral/kvaciral/main/kvaciral.asc | gpg --import
 
-ENV BITCOIN_VERSION=23.0
+ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
@@ -128,7 +128,7 @@ RUN apk --no-cache add \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV BITCOIN_VERSION=23.0
+ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A bitcoin-core docker image with support for the following platforms:
 - `24.0.1`, `24`, `latest` ([24/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/Dockerfile)) [**multi-arch**]
 - `24.0.1-alpine`, `24-alpine` ([24/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/alpine/Dockerfile))
 
-- `23.0`, `23` ([23/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/Dockerfile)) [**multi-arch**]
-- `23.0-alpine`, `23-alpine` ([23/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/alpine/Dockerfile))
+- `23.2`, `23` ([23/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/Dockerfile)) [**multi-arch**]
+- `23.2-alpine`, `23-alpine` ([23/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/alpine/Dockerfile))
 
 - `22.0`, `22`, ([22/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/22/Dockerfile)) [**multi-arch**]
 - `22.0-alpine`, `22-alpine` ([22/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/22/alpine/Dockerfile))


### PR DESCRIPTION
Migrate to the latest point release of the 23.x series.

https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.1.md 
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.2.md

Similar to #136.