### PR TITLE
24: prune no-longer-needed Boost libs

### DIFF
--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -110,9 +110,6 @@ RUN addgroup bitcoin --gid ${GID} --system
 RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
-  boost-filesystem \
-  boost-system \
-  boost-thread \
   libevent \
   libzmq \
   shadow \


### PR DESCRIPTION
These haven't been required since Bitcoin Core 23.0.