### PR TITLE
Add v25.1, update minor releases, use bitcoincore.org, verify using bitcoin core verify script, fixup alpine builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '25'
+          - '25/alpine'
           - '24'
           - '24/alpine'
           - '23'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '26'
+          - '26/alpine'
           - '25'
           - '25/alpine'
           - '24'

--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-linux64.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-linux64.tar.gz \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-linux64.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.11/alpine/Dockerfile
+++ b/0.11/alpine/Dockerfile
@@ -62,8 +62,8 @@ RUN update-ca-certificates
 ENV BITCOIN_VERSION=0.11.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN curl -O https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN curl -O https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN curl -O https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN curl -O https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-linux64.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-linux64.tar.gz \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-linux64.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.12/alpine/Dockerfile
+++ b/0.12/alpine/Dockerfile
@@ -56,8 +56,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.12.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.13/Dockerfile
+++ b/0.13/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.13/Dockerfile
+++ b/0.13/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.13/alpine/Dockerfile
+++ b/0.13/alpine/Dockerfile
@@ -56,8 +56,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.13.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.16/alpine/Dockerfile
+++ b/0.16/alpine/Dockerfile
@@ -56,8 +56,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.16.3
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.17/alpine/Dockerfile
+++ b/0.17/alpine/Dockerfile
@@ -56,8 +56,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.17.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.18/Dockerfile
+++ b/0.18/Dockerfile
@@ -28,8 +28,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.18/Dockerfile
+++ b/0.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.18/alpine/Dockerfile
+++ b/0.18/alpine/Dockerfile
@@ -56,8 +56,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.18.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -32,8 +32,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz\$" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.19/alpine/Dockerfile
+++ b/0.19/alpine/Dockerfile
@@ -55,8 +55,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.19.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.19/alpine/Dockerfile
+++ b/0.19/alpine/Dockerfile
@@ -23,7 +23,7 @@ RUN make install
 RUN rm -rf ${BERKELEYDB_PREFIX}/docs
 
 # Build stage for Bitcoin Core
-FROM alpine as bitcoin-core
+FROM alpine:3.13.0 as bitcoin-core
 
 COPY --from=berkeleydb /opt /opt
 
@@ -79,6 +79,12 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-daemon
 RUN make -j4
 RUN make install
+
+# copy libs needed to run on latest alpine
+RUN mkdir /staging-libs && \
+    ldd ${BITCOIN_PREFIX}/bin/bitcoind | awk '$1 ~ /^\// {print $1} $3 ~ /^\// {print $3}' | \
+    while read -r lib; do cp "$lib" /staging-libs/; done
+
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
@@ -98,15 +104,14 @@ RUN addgroup -S bitcoin
 RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
-  boost-chrono \
-  boost-filesystem \
-  boost-system \
-  boost-thread \
-  libevent \
   libressl \
   libzmq \
   shadow \
   su-exec
+
+# Copy libraries from the builder stage
+RUN mkdir -p /usr/local/lib
+COPY --from=bitcoin-core /staging-libs/* /usr/local/lib/
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV BITCOIN_VERSION=0.19.1

--- a/0.20/Dockerfile
+++ b/0.20/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/0.20/Dockerfile
+++ b/0.20/Dockerfile
@@ -32,8 +32,8 @@ RUN set -ex \
       gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
       gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
     done \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
-  && curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
   && gpg --verify SHA256SUMS.asc \
   && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS.asc | sha256sum -c - \
   && tar -xzf *.tar.gz -C /opt \

--- a/0.20/alpine/Dockerfile
+++ b/0.20/alpine/Dockerfile
@@ -23,7 +23,7 @@ RUN make install
 RUN rm -rf ${BERKELEYDB_PREFIX}/docs
 
 # Build stage for Bitcoin Core
-FROM alpine as bitcoin-core
+FROM alpine:3.13.0 as bitcoin-core
 
 COPY --from=berkeleydb /opt /opt
 
@@ -78,6 +78,11 @@ RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/incl
     --with-daemon
 RUN make -j4
 RUN make install
+
+# copy libs needed to run on latest alpine
+RUN mkdir /staging-libs && \
+    ldd ${BITCOIN_PREFIX}/bin/bitcoind | awk '$1 ~ /^\// {print $1} $3 ~ /^\// {print $3}' | \
+    while read -r lib; do cp "$lib" /staging-libs/; done
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
@@ -97,13 +102,13 @@ RUN addgroup -S bitcoin
 RUN adduser -G bitcoin -H -S bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
-  boost-filesystem \
-  boost-system \
-  boost-thread \
-  libevent \
   libzmq \
   shadow \
   su-exec
+
+# Copy libraries from the builder stage
+RUN mkdir -p /usr/local/lib
+COPY --from=bitcoin-core /staging-libs/* /usr/local/lib/
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV BITCOIN_VERSION=0.20.1

--- a/0.20/alpine/Dockerfile
+++ b/0.20/alpine/Dockerfile
@@ -54,8 +54,8 @@ RUN set -ex \
 ENV BITCOIN_VERSION=0.20.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
 RUN gpg --verify SHA256SUMS.asc
 RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS.asc | sha256sum -c -
 RUN tar -xzf *.tar.gz

--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -15,7 +15,7 @@ RUN groupadd --gid ${GID} bitcoin \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
-ENV BITCOIN_VERSION=22.0
+ENV BITCOIN_VERSION=22.1
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
@@ -32,7 +32,7 @@ RUN set -ex \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
 
 # Second stage
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -1,67 +1,60 @@
-FROM debian:bullseye-slim
-
-ARG UID=101
-ARG GID=101
+FROM debian:bullseye-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN groupadd --gid ${GID} bitcoin \
-  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
-  && apt-get update -y \
-  && apt-get install -y curl gnupg gosu \
+RUN apt-get update -y \
+  && apt-get install -y ca-certificates curl git gnupg gosu python3 wget --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
 ENV BITCOIN_VERSION=22.1
-ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/verify-binaries/verify.py"
+ENV TMPDIR="/tmp/bitcoin_verify_binaries"
 
 RUN set -ex \
   && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
-  && for key in \
-    0CCBAAFD76A2ECE2CCD3141DE2FFD5B1D88CA97D \
-    152812300785C96444D3334D17565732E08E5E41 \
-    0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-    590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-    28F5900B1BB5D1A4B6B6D1A9ED357015286A333D \
-    637DB1E23370F84AFF88CCE03152347D07DA627C \
-    CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-    6E01EEC9656903B0542B8F1003DB6322267C373B \
-    D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-    82921A4B88FD454B7EB8CE3C796C4109063D4EAF \
-    9DEAE0DC7063249FB05474681E4AED62986CD25D \
-    9D3CC86A72F8494342EA5FD10A41BDC3F4FAFF1C \
-    74E2DEF5D77260B98BC19438099BAD163C70FBFA \
-  ; do \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-      gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-      gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-    done \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && gpg --verify SHA256SUMS.asc SHA256SUMS \
-  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
-  && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && curl -o verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py \
+    --min-good-sigs 6 pub "${BITCOIN_VERSION}-linux" \
+  && tar -xzf "${TMPDIR}.${BITCOIN_VERSION}-linux/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" -C /opt \
+  && rm -rf ${SIGS_CLONE_DIR} \
+  && rm -rf ${TMPDIR} \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+# Second stage
+FROM debian:bullseye-slim
+
+ARG UID=101
+ARG GID=101
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=22.1
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y gosu --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /opt/bitcoin-${BITCOIN_VERSION} /opt/bitcoin-${BITCOIN_VERSION}
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
-
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
 
 ENTRYPOINT ["/entrypoint.sh"]
-
 RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
-
 CMD ["bitcoind"]

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
     gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
   done
 
-ENV BITCOIN_VERSION=22.0
+ENV BITCOIN_VERSION=22.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
@@ -122,7 +122,7 @@ RUN apk --no-cache add \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV BITCOIN_VERSION=22.0
+ENV BITCOIN_VERSION=22.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
 

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p ${BERKELEYDB_PREFIX}
 
 WORKDIR /${BERKELEYDB_VERSION}/build_unix
 
-RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
 RUN make -j4
 RUN make install
 RUN rm -rf ${BERKELEYDB_PREFIX}/docs
@@ -35,62 +35,53 @@ RUN apk --no-cache add build-base
 RUN apk --no-cache add chrpath
 RUN apk --no-cache add file
 RUN apk --no-cache add gnupg
+RUN apk --no-cache add git
 RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
-RUN set -ex \
-  && for key in \
-    0CCBAAFD76A2ECE2CCD3141DE2FFD5B1D88CA97D \
-    152812300785C96444D3334D17565732E08E5E41 \
-    0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-    590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-    28F5900B1BB5D1A4B6B6D1A9ED357015286A333D \
-    637DB1E23370F84AFF88CCE03152347D07DA627C \
-    CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-    6E01EEC9656903B0542B8F1003DB6322267C373B \
-    D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-    82921A4B88FD454B7EB8CE3C796C4109063D4EAF \
-    9DEAE0DC7063249FB05474681E4AED62986CD25D \
-    9D3CC86A72F8494342EA5FD10A41BDC3F4FAFF1C \
-    74E2DEF5D77260B98BC19438099BAD163C70FBFA \
-  ; do \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done
 
 ENV BITCOIN_VERSION=22.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV BITCOIN_SOURCE_DIR=/bitcoin/src
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://github.com/bitcoin/bitcoin/raw/master/contrib/verify-binaries/verify.py"
 
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
-RUN gpg --verify SHA256SUMS.asc SHA256SUMS
-RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
-RUN tar -xzf *.tar.gz
+WORKDIR /bitcoin
+RUN set -ex \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && wget -O verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py bin SHA256SUMS \
+    "bitcoin-${BITCOIN_VERSION}.tar.gz" \
+  && mkdir -p ${BITCOIN_SOURCE_DIR} \
+  && tar -xzf "bitcoin-${BITCOIN_VERSION}.tar.gz" -C ${BITCOIN_SOURCE_DIR} \
+  && rm -rf ${SIGS_CLONE_DIR}
 
-WORKDIR /bitcoin-${BITCOIN_VERSION}
+WORKDIR "${BITCOIN_SOURCE_DIR}/bitcoin-${BITCOIN_VERSION}"
 
 RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
 RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
 RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
 RUN ./autogen.sh
 RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
-    --prefix=${BITCOIN_PREFIX} \
-    --mandir=/usr/share/man \
-    --disable-tests \
-    --disable-bench \
-    --disable-ccache \
-    --with-gui=no \
-    --with-utils \
-    --with-libs \
-    --with-sqlite=yes \
-    --with-daemon
+  --prefix=${BITCOIN_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-libs \
+  --with-sqlite=yes \
+  --with-daemon
 RUN make -j4
 RUN make install
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
@@ -99,6 +90,7 @@ RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
 RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
 
+# Build stage for compiled artifacts
 FROM alpine
 
 ARG UID=100

--- a/23/Dockerfile
+++ b/23/Dockerfile
@@ -15,7 +15,7 @@ RUN groupadd --gid ${GID} bitcoin \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
-ENV BITCOIN_VERSION=23.0
+ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 

--- a/23/Dockerfile
+++ b/23/Dockerfile
@@ -1,71 +1,60 @@
-FROM debian:bullseye-slim
-
-ARG UID=101
-ARG GID=101
+FROM debian:bullseye-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN groupadd --gid ${GID} bitcoin \
-  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
-  && apt-get update -y \
-  && apt-get install -y curl gnupg gosu \
+RUN apt-get update -y \
+  && apt-get install -y ca-certificates curl git gnupg gosu python3 wget --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
 ENV BITCOIN_VERSION=23.2
-ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/verify-binaries/verify.py"
+ENV TMPDIR="/tmp/bitcoin_verify_binaries"
 
 RUN set -ex \
   && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
-  && for key in \
-    152812300785C96444D3334D17565732E08E5E41 \
-    0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-    590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-    28F5900B1BB5D1A4B6B6D1A9ED357015286A333D \
-    637DB1E23370F84AFF88CCE03152347D07DA627C \
-    CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-    F4FC70F07310028424EFC20A8E4256593F177720 \
-    D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-    287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-    F9A8737BF4FF5C89C903DF31DD78544CF91B1514 \
-    9DEAE0DC7063249FB05474681E4AED62986CD25D \
-    E463A93F5F3117EEDE6C7316BD02942421F4889F \
-    9D3CC86A72F8494342EA5FD10A41BDC3F4FAFF1C \
-    4DAF18FE948E7A965B30F9457E296D555E7F63A7 \
-    28E72909F1717FE9607754F8A7BEB2621678D37D \
-    74E2DEF5D77260B98BC19438099BAD163C70FBFA \
-  ; do \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-      gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-      gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-    done \
-  && curl -SL https://raw.githubusercontent.com/Kvaciral/kvaciral/main/kvaciral.asc | gpg --import \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && gpg --verify SHA256SUMS.asc SHA256SUMS \
-  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
-  && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && curl -o verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py \
+    --min-good-sigs 6 pub "${BITCOIN_VERSION}-linux" \
+  && tar -xzf "${TMPDIR}.${BITCOIN_VERSION}-linux/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" -C /opt \
+  && rm -rf ${SIGS_CLONE_DIR} \
+  && rm -rf ${TMPDIR} \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+# Second stage
+FROM debian:bullseye-slim
+
+ARG UID=101
+ARG GID=101
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=23.2
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y gosu --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /opt/bitcoin-${BITCOIN_VERSION} /opt/bitcoin-${BITCOIN_VERSION}
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
-
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
 
 ENTRYPOINT ["/entrypoint.sh"]
-
 RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
-
 CMD ["bitcoind"]

--- a/23/Dockerfile
+++ b/23/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
@@ -32,7 +32,7 @@ RUN set -ex \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
 
 # Second stage
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/23/alpine/Dockerfile
+++ b/23/alpine/Dockerfile
@@ -1,8 +1,6 @@
 # Build stage for BerkeleyDB
 FROM alpine as berkeleydb
 
-ARG TARGETPLATFORM
-
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add autoconf
 RUN apk --no-cache add automake
@@ -19,7 +17,7 @@ RUN mkdir -p ${BERKELEYDB_PREFIX}
 
 WORKDIR /${BERKELEYDB_VERSION}/build_unix
 
-RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
 RUN make -j4
 RUN make install
 RUN rm -rf ${BERKELEYDB_PREFIX}/docs
@@ -37,66 +35,53 @@ RUN apk --no-cache add build-base
 RUN apk --no-cache add chrpath
 RUN apk --no-cache add file
 RUN apk --no-cache add gnupg
+RUN apk --no-cache add git
 RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
-RUN set -ex \
-  && for key in \
-    152812300785C96444D3334D17565732E08E5E41 \
-    0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-    590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-    28F5900B1BB5D1A4B6B6D1A9ED357015286A333D \
-    637DB1E23370F84AFF88CCE03152347D07DA627C \
-    CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-    F4FC70F07310028424EFC20A8E4256593F177720 \
-    D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-    287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-    F9A8737BF4FF5C89C903DF31DD78544CF91B1514 \
-    9DEAE0DC7063249FB05474681E4AED62986CD25D \
-    E463A93F5F3117EEDE6C7316BD02942421F4889F \
-    9D3CC86A72F8494342EA5FD10A41BDC3F4FAFF1C \
-    4DAF18FE948E7A965B30F9457E296D555E7F63A7 \
-    28E72909F1717FE9607754F8A7BEB2621678D37D \
-    74E2DEF5D77260B98BC19438099BAD163C70FBFA \
-  ; do \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done && \
-  wget -O- https://raw.githubusercontent.com/Kvaciral/kvaciral/main/kvaciral.asc | gpg --import
 
 ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV BITCOIN_SOURCE_DIR=/bitcoin/src
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://github.com/bitcoin/bitcoin/raw/master/contrib/verify-binaries/verify.py"
 
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
-RUN gpg --verify SHA256SUMS.asc SHA256SUMS
-RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
-RUN tar -xzf *.tar.gz
+WORKDIR /bitcoin
+RUN set -ex \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && wget -O verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py bin SHA256SUMS \
+    "bitcoin-${BITCOIN_VERSION}.tar.gz" \
+  && mkdir -p ${BITCOIN_SOURCE_DIR} \
+  && tar -xzf "bitcoin-${BITCOIN_VERSION}.tar.gz" -C ${BITCOIN_SOURCE_DIR} \
+  && rm -rf ${SIGS_CLONE_DIR}
 
-WORKDIR /bitcoin-${BITCOIN_VERSION}
+WORKDIR "${BITCOIN_SOURCE_DIR}/bitcoin-${BITCOIN_VERSION}"
 
 RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
 RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
 RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
 RUN ./autogen.sh
 RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
-    --prefix=${BITCOIN_PREFIX} \
-    --mandir=/usr/share/man \
-    --disable-tests \
-    --disable-bench \
-    --disable-ccache \
-    --with-gui=no \
-    --with-utils \
-    --with-libs \
-    --with-sqlite=yes \
-    --with-daemon
+  --prefix=${BITCOIN_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-libs \
+  --with-sqlite=yes \
+  --with-daemon
 RUN make -j4
 RUN make install
 RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
@@ -122,9 +107,10 @@ RUN apk --no-cache add \
   boost-filesystem \
   boost-system \
   boost-thread \
-  sqlite-dev \
   libevent \
   libzmq \
+  shadow \
+  sqlite-dev \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin

--- a/23/alpine/Dockerfile
+++ b/23/alpine/Dockerfile
@@ -70,7 +70,7 @@ RUN set -ex \
   done && \
   wget -O- https://raw.githubusercontent.com/Kvaciral/kvaciral/main/kvaciral.asc | gpg --import
 
-ENV BITCOIN_VERSION=23.0
+ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
@@ -128,7 +128,7 @@ RUN apk --no-cache add \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV BITCOIN_VERSION=23.0
+ENV BITCOIN_VERSION=23.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
 

--- a/24/Dockerfile
+++ b/24/Dockerfile
@@ -15,7 +15,7 @@ RUN groupadd --gid ${GID} bitcoin \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
-ENV BITCOIN_VERSION=24.0.1
+ENV BITCOIN_VERSION=24.2
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 

--- a/24/Dockerfile
+++ b/24/Dockerfile
@@ -1,66 +1,60 @@
-FROM debian:bullseye-slim
-
-ARG UID=101
-ARG GID=101
+FROM debian:bullseye-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN groupadd --gid ${GID} bitcoin \
-  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
-  && apt-get update -y \
-  && apt-get install -y curl gnupg gosu \
+RUN apt-get update -y \
+  && apt-get install -y ca-certificates curl git gnupg gosu python3 wget --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
 ENV BITCOIN_VERSION=24.2
-ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/verify-binaries/verify.py"
+ENV TMPDIR="/tmp/bitcoin_verify_binaries"
 
 RUN set -ex \
   && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
-  && for key in \
-  152812300785C96444D3334D17565732E08E5E41 \
-  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-  590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-  F4FC70F07310028424EFC20A8E4256593F177720 \
-  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-  9DEAE0DC7063249FB05474681E4AED62986CD25D \
-  3EB0DEE6004A13BE5A0CC758BF2978B068054311 \
-  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
-  28E72909F1717FE9607754F8A7BEB2621678D37D \
-  79D00BAC68B56D422F945A8F8E3A8F3247DBCBBF \
-  ; do \
-  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && gpg --verify SHA256SUMS.asc SHA256SUMS \
-  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
-  && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && curl -o verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py \
+    --min-good-sigs 6 pub "${BITCOIN_VERSION}-linux" \
+  && tar -xzf "${TMPDIR}.${BITCOIN_VERSION}-linux/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" -C /opt \
+  && rm -rf ${SIGS_CLONE_DIR} \
+  && rm -rf ${TMPDIR} \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+# Second stage
+FROM debian:bullseye-slim
+
+ARG UID=101
+ARG GID=101
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=24.2
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y gosu --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /opt/bitcoin-${BITCOIN_VERSION} /opt/bitcoin-${BITCOIN_VERSION}
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
-
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
 
 ENTRYPOINT ["/entrypoint.sh"]
-
 RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
-
 CMD ["bitcoind"]

--- a/24/Dockerfile
+++ b/24/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
@@ -32,7 +32,7 @@ RUN set -ex \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
 
 # Second stage
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -35,45 +35,37 @@ RUN apk --no-cache add build-base
 RUN apk --no-cache add chrpath
 RUN apk --no-cache add file
 RUN apk --no-cache add gnupg
+RUN apk --no-cache add git
 RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
-RUN set -ex \
-  && for key in \
-  152812300785C96444D3334D17565732E08E5E41 \
-  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-  590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-  F4FC70F07310028424EFC20A8E4256593F177720 \
-  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-  9DEAE0DC7063249FB05474681E4AED62986CD25D \
-  3EB0DEE6004A13BE5A0CC758BF2978B068054311 \
-  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
-  28E72909F1717FE9607754F8A7BEB2621678D37D \
-  79D00BAC68B56D422F945A8F8E3A8F3247DBCBBF \
-  ; do \
-  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done
 
 ENV BITCOIN_VERSION=24.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV BITCOIN_SOURCE_DIR=/bitcoin/src
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://github.com/bitcoin/bitcoin/raw/master/contrib/verify-binaries/verify.py"
 
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
-RUN gpg --verify SHA256SUMS.asc SHA256SUMS
-RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
-RUN tar -xzf *.tar.gz
+WORKDIR /bitcoin
+RUN set -ex \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && wget -O verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py bin SHA256SUMS \
+    "bitcoin-${BITCOIN_VERSION}.tar.gz" \
+  && mkdir -p ${BITCOIN_SOURCE_DIR} \
+  && tar -xzf "bitcoin-${BITCOIN_VERSION}.tar.gz" -C ${BITCOIN_SOURCE_DIR} \
+  && rm -rf ${SIGS_CLONE_DIR}
 
-WORKDIR /bitcoin-${BITCOIN_VERSION}
+WORKDIR "${BITCOIN_SOURCE_DIR}/bitcoin-${BITCOIN_VERSION}"
 
 RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h
 RUN ./autogen.sh

--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -102,9 +102,6 @@ RUN addgroup bitcoin --gid ${GID} --system
 RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
-  boost-filesystem \
-  boost-system \
-  boost-thread \
   libevent \
   libzmq \
   shadow \

--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -63,7 +63,7 @@ RUN set -ex \
   gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
   done
 
-ENV BITCOIN_VERSION=24.0.1
+ENV BITCOIN_VERSION=24.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
@@ -120,7 +120,7 @@ RUN apk --no-cache add \
   su-exec
 
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV BITCOIN_VERSION=24.0.1
+ENV BITCOIN_VERSION=24.2
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
 ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
 

--- a/25/Dockerfile
+++ b/25/Dockerfile
@@ -1,0 +1,66 @@
+FROM debian:bullseye-slim
+
+ARG UID=101
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg gosu \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG TARGETPLATFORM
+ENV BITCOIN_VERSION=25.1
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
+  && for key in \
+  152812300785C96444D3334D17565732E08E5E41 \
+  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
+  590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
+  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
+  F4FC70F07310028424EFC20A8E4256593F177720 \
+  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
+  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
+  9DEAE0DC7063249FB05474681E4AED62986CD25D \
+  3EB0DEE6004A13BE5A0CC758BF2978B068054311 \
+  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
+  28E72909F1717FE9607754F8A7BEB2621678D37D \
+  79D00BAC68B56D422F945A8F8E3A8F3247DBCBBF \
+  ; do \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && gpg --verify SHA256SUMS.asc SHA256SUMS \
+  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
+  && tar -xzf *.tar.gz -C /opt \
+  && rm *.tar.gz *.asc \
+  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/25/Dockerfile
+++ b/25/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
@@ -32,7 +32,7 @@ RUN set -ex \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
 
 # Second stage
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG UID=101
 ARG GID=101

--- a/25/Dockerfile
+++ b/25/Dockerfile
@@ -1,66 +1,60 @@
-FROM debian:bullseye-slim
-
-ARG UID=101
-ARG GID=101
+FROM debian:bullseye-slim as builder
 
 LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
   maintainer.1="Pedro Branco (@pedrobranco)" \
   maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN groupadd --gid ${GID} bitcoin \
-  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
-  && apt-get update -y \
-  && apt-get install -y curl gnupg gosu \
+RUN apt-get update -y \
+  && apt-get install -y ca-certificates curl git gnupg gosu python3 wget --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG TARGETPLATFORM
 ENV BITCOIN_VERSION=25.1
-ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
-ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/verify-binaries/verify.py"
+ENV TMPDIR="/tmp/bitcoin_verify_binaries"
 
 RUN set -ex \
   && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
-  && for key in \
-  152812300785C96444D3334D17565732E08E5E41 \
-  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-  590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-  F4FC70F07310028424EFC20A8E4256593F177720 \
-  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-  9DEAE0DC7063249FB05474681E4AED62986CD25D \
-  3EB0DEE6004A13BE5A0CC758BF2978B068054311 \
-  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
-  28E72909F1717FE9607754F8A7BEB2621678D37D \
-  79D00BAC68B56D422F945A8F8E3A8F3247DBCBBF \
-  ; do \
-  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
-  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
-  && gpg --verify SHA256SUMS.asc SHA256SUMS \
-  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
-  && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && curl -o verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py \
+    --min-good-sigs 6 pub "${BITCOIN_VERSION}-linux" \
+  && tar -xzf "${TMPDIR}.${BITCOIN_VERSION}-linux/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" -C /opt \
+  && rm -rf ${SIGS_CLONE_DIR} \
+  && rm -rf ${TMPDIR} \
   && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+# Second stage
+FROM debian:bullseye-slim
+
+ARG UID=101
+ARG GID=101
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=25.1
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y gosu --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /opt/bitcoin-${BITCOIN_VERSION} /opt/bitcoin-${BITCOIN_VERSION}
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
-
 EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
 
 ENTRYPOINT ["/entrypoint.sh"]
-
 RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
-
 CMD ["bitcoind"]

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -35,45 +35,37 @@ RUN apk --no-cache add build-base
 RUN apk --no-cache add chrpath
 RUN apk --no-cache add file
 RUN apk --no-cache add gnupg
+RUN apk --no-cache add git
 RUN apk --no-cache add libevent-dev
 RUN apk --no-cache add libressl
 RUN apk --no-cache add libtool
 RUN apk --no-cache add linux-headers
 RUN apk --no-cache add sqlite-dev
 RUN apk --no-cache add zeromq-dev
-RUN set -ex \
-  && for key in \
-  152812300785C96444D3334D17565732E08E5E41 \
-  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-  590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
-  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-  F4FC70F07310028424EFC20A8E4256593F177720 \
-  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-  9DEAE0DC7063249FB05474681E4AED62986CD25D \
-  3EB0DEE6004A13BE5A0CC758BF2978B068054311 \
-  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
-  28E72909F1717FE9607754F8A7BEB2621678D37D \
-  79D00BAC68B56D422F945A8F8E3A8F3247DBCBBF \
-  ; do \
-  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done
 
 ENV BITCOIN_VERSION=25.1
 ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV BITCOIN_SOURCE_DIR=/bitcoin/src
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://github.com/bitcoin/bitcoin/raw/master/contrib/verify-binaries/verify.py"
 
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
-RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
-RUN gpg --verify SHA256SUMS.asc SHA256SUMS
-RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
-RUN tar -xzf *.tar.gz
+WORKDIR /bitcoin
+RUN set -ex \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && wget -O verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py bin SHA256SUMS \
+    "bitcoin-${BITCOIN_VERSION}.tar.gz" \
+  && mkdir -p ${BITCOIN_SOURCE_DIR} \
+  && tar -xzf "bitcoin-${BITCOIN_VERSION}.tar.gz" -C ${BITCOIN_SOURCE_DIR} \
+  && rm -rf ${SIGS_CLONE_DIR}
 
-WORKDIR /bitcoin-${BITCOIN_VERSION}
+WORKDIR "${BITCOIN_SOURCE_DIR}/bitcoin-${BITCOIN_VERSION}"
 
 RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h
 RUN ./autogen.sh

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -102,9 +102,6 @@ RUN addgroup bitcoin --gid ${GID} --system
 RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
 RUN apk --no-cache add \
-  boost-filesystem \
-  boost-system \
-  boost-thread \
   libevent \
   libzmq \
   shadow \

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -1,0 +1,138 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add libressl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Bitcoin Core
+FROM alpine as bitcoin-core
+
+COPY --from=berkeleydb /opt /opt
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add boost-dev
+RUN apk --no-cache add build-base
+RUN apk --no-cache add chrpath
+RUN apk --no-cache add file
+RUN apk --no-cache add gnupg
+RUN apk --no-cache add libevent-dev
+RUN apk --no-cache add libressl
+RUN apk --no-cache add libtool
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
+RUN apk --no-cache add zeromq-dev
+RUN set -ex \
+  && for key in \
+  152812300785C96444D3334D17565732E08E5E41 \
+  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
+  590B7292695AFFA5B672CBB2E13FC145CD3F4304 \
+  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
+  F4FC70F07310028424EFC20A8E4256593F177720 \
+  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
+  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
+  9DEAE0DC7063249FB05474681E4AED62986CD25D \
+  3EB0DEE6004A13BE5A0CC758BF2978B068054311 \
+  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
+  28E72909F1717FE9607754F8A7BEB2621678D37D \
+  79D00BAC68B56D422F945A8F8E3A8F3247DBCBBF \
+  ; do \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
+
+ENV BITCOIN_VERSION=25.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN gpg --verify SHA256SUMS.asc SHA256SUMS
+RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
+RUN tar -xzf *.tar.gz
+
+WORKDIR /bitcoin-${BITCOIN_VERSION}
+
+RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h
+RUN ./autogen.sh
+RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+  --prefix=${BITCOIN_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-libs \
+  --with-sqlite=yes \
+  --with-daemon
+RUN make -j4
+RUN make install
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
+
+# Build stage for compiled artifacts
+FROM alpine
+
+ARG UID=100
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add \
+  boost-filesystem \
+  boost-system \
+  boost-thread \
+  libevent \
+  libzmq \
+  shadow \
+  sqlite-dev \
+  su-exec
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=25.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+
+COPY --from=bitcoin-core /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/25/alpine/docker-entrypoint.sh
+++ b/25/alpine/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec su-exec bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/25/docker-entrypoint.sh
+++ b/25/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec gosu bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -1,0 +1,60 @@
+FROM debian:bookworm-slim as builder
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN apt-get update -y \
+  && apt-get install -y ca-certificates curl git gnupg gosu python3 wget --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG TARGETPLATFORM
+ENV BITCOIN_VERSION=26.1
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/verify-binaries/verify.py"
+ENV TMPDIR="/tmp/bitcoin_verify_binaries"
+
+RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && curl -o verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py \
+    --min-good-sigs 6 pub "${BITCOIN_VERSION}-linux" \
+  && tar -xzf "${TMPDIR}.${BITCOIN_VERSION}-linux/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" -C /opt \
+  && rm -rf ${SIGS_CLONE_DIR} \
+  && rm -rf ${TMPDIR} \
+  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+# Second stage
+FROM debian:bookworm-slim
+
+ARG UID=101
+ARG GID=101
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=26.1
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y gosu --no-install-recommends \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /opt/bitcoin-${BITCOIN_VERSION} /opt/bitcoin-${BITCOIN_VERSION}
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+CMD ["bitcoind"]

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -1,0 +1,127 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add libressl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Bitcoin Core
+FROM alpine as bitcoin-core
+
+COPY --from=berkeleydb /opt /opt
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add boost-dev
+RUN apk --no-cache add build-base
+RUN apk --no-cache add chrpath
+RUN apk --no-cache add file
+RUN apk --no-cache add gnupg
+RUN apk --no-cache add git
+RUN apk --no-cache add libevent-dev
+RUN apk --no-cache add libressl
+RUN apk --no-cache add libtool
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
+RUN apk --no-cache add zeromq-dev
+
+ENV BITCOIN_VERSION=26.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV BITCOIN_SOURCE_DIR=/bitcoin/src
+ENV SIGS_REPO_URL="https://github.com/bitcoin-core/guix.sigs.git"
+ENV SIGS_CLONE_DIR="guix.sigs"
+ENV VERIFY_SCRIPT_URL="https://github.com/bitcoin/bitcoin/raw/master/contrib/verify-binaries/verify.py"
+
+WORKDIR /bitcoin
+RUN set -ex \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && git clone ${SIGS_REPO_URL} ${SIGS_CLONE_DIR} \
+  && gpg --import "${SIGS_CLONE_DIR}"/builder-keys/* \
+  && wget -O verify.py ${VERIFY_SCRIPT_URL} \
+  && chmod +x verify.py \
+  && ./verify.py bin SHA256SUMS \
+    "bitcoin-${BITCOIN_VERSION}.tar.gz" \
+  && mkdir -p ${BITCOIN_SOURCE_DIR} \
+  && tar -xzf "bitcoin-${BITCOIN_VERSION}.tar.gz" -C ${BITCOIN_SOURCE_DIR} \
+  && rm -rf ${SIGS_CLONE_DIR}
+
+WORKDIR "${BITCOIN_SOURCE_DIR}/bitcoin-${BITCOIN_VERSION}"
+
+RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h
+RUN ./autogen.sh
+RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+  --prefix=${BITCOIN_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-libs \
+  --with-sqlite=yes \
+  --with-daemon
+RUN make -j4
+RUN make install
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
+
+# Build stage for compiled artifacts
+FROM alpine
+
+ARG UID=100
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add \
+  libevent \
+  libzmq \
+  shadow \
+  sqlite-dev \
+  su-exec
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=26.1
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+
+COPY --from=bitcoin-core /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/26/alpine/docker-entrypoint.sh
+++ b/26/alpine/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec su-exec bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/26/docker-entrypoint.sh
+++ b/26/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec gosu bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ A bitcoin-core docker image with support for the following platforms:
 
 ## Tags
 
+- `25.1`, `25`, `latest` ([25/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/Dockerfile)) [**multi-arch**]
+- `25.1-alpine`, `25-alpine` ([25/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/alpine/Dockerfile))
+
 - `24.2`, `24`, `latest` ([24/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/Dockerfile)) [**multi-arch**]
 - `24.2-alpine`, `24-alpine` ([24/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/alpine/Dockerfile))
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ A bitcoin-core docker image with support for the following platforms:
 
 ## Tags
 
-- `24.0.1`, `24`, `latest` ([24/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/Dockerfile)) [**multi-arch**]
-- `24.0.1-alpine`, `24-alpine` ([24/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/alpine/Dockerfile))
+- `24.2`, `24`, `latest` ([24/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/Dockerfile)) [**multi-arch**]
+- `24.2-alpine`, `24-alpine` ([24/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/alpine/Dockerfile))
 
-- `23.0`, `23` ([23/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/Dockerfile)) [**multi-arch**]
-- `23.0-alpine`, `23-alpine` ([23/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/alpine/Dockerfile))
+- `23.2`, `23` ([23/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/Dockerfile)) [**multi-arch**]
+- `23.2-alpine`, `23-alpine` ([23/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/alpine/Dockerfile))
 
-- `22.0`, `22`, ([22/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/22/Dockerfile)) [**multi-arch**]
-- `22.0-alpine`, `22-alpine` ([22/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/22/alpine/Dockerfile))
+- `22.1`, `22`, ([22/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/22/Dockerfile)) [**multi-arch**]
+- `22.1-alpine`, `22-alpine` ([22/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/22/alpine/Dockerfile))
 
 - `0.21.1`, `0.21` ([0.21/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.21/Dockerfile)) [**multi-arch**]
 - `0.21.1-alpine`, `0.21-alpine` ([0.21/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/0.21/alpine/Dockerfile))

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ A bitcoin-core docker image with support for the following platforms:
 
 ## Tags
 
+- `26.1`, `26`, `latest` ([26/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/26/Dockerfile)) [**multi-arch**]
+- `26.1-alpine`, `26-alpine` ([26/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/26/alpine/Dockerfile))
+
 - `25.1`, `25`, `latest` ([25/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/Dockerfile)) [**multi-arch**]
 - `25.1-alpine`, `25-alpine` ([25/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/alpine/Dockerfile))
 


### PR DESCRIPTION
This pull includes a number of changes:

* fix broken older builds, and update some minor point releases
* add v25.1
* switch default binary repository to bitcoincore.org for better reliability 
* use the bitcoin core `verify-binaries/verify.py` script to simplify downloading and verifying versions >= v22.0  which are now [signed by keys found in the guix.sigs repository](https://github.com/bitcoin/bitcoin/tree/master/contrib/verify-binaries)
* lock builds to debian:bookworm-slim

Each commit message contains additional detail on the rationale and implementation.

If I got this right, this should also:

close #140 
close #139 
close #138 
close #137
close #136

I'd like to see this, or something like this, merged and have updated images available from this repo, so let me know if you'd like any changes from me to move this forward.