### PR TITLE
Add bitcoin-core@28.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '28'
+          - '28/alpine'
           - '24'
           - '24/alpine'
           - '23'

--- a/28/Dockerfile
+++ b/28/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:bullseye-slim
+
+ARG UID=101
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg gosu \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG TARGETPLATFORM
+ENV BITCOIN_VERSION=28.0
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
+  && curl -fsSL https://github.com/bitcoin-core/guix.sigs/archive/refs/heads/main.tar.gz \
+  | tar -xz --strip-components=1 guix.sigs-main/builder-keys/ \
+  && gpg --import builder-keys/*.gpg \
+  && rm -rf builder-keys \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && gpg --verify SHA256SUMS.asc SHA256SUMS \
+  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
+  && tar -xzf *.tar.gz -C /opt \
+  && rm *.tar.gz *.asc \
+  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/28/alpine/Dockerfile
+++ b/28/alpine/Dockerfile
@@ -1,0 +1,135 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add libressl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Bitcoin Core
+FROM alpine as bitcoin-core
+
+COPY --from=berkeleydb /opt /opt
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add boost-dev
+RUN apk --no-cache add build-base
+RUN apk --no-cache add chrpath
+RUN apk --no-cache add file
+RUN apk --no-cache add gnupg
+RUN apk --no-cache add libevent-dev
+RUN apk --no-cache add libressl
+RUN apk --no-cache add libtool
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
+RUN apk --no-cache add zeromq-dev
+RUN set -ex \
+  && for key in \
+  152812300785C96444D3334D17565732E08E5E41 \
+  E777299FC265DD04793070EB944D35F9AC3DB76A \
+  71A3B16735405025D447E8F274810B012346C9A6 \
+  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
+  6B002C6EA3F91B1B0DF0C9BC8F617F1200A6D25C \
+  133EAC179436F14A5CF1B794860FEB804E669320 \
+  F4FC70F07310028424EFC20A8E4256593F177720 \
+  67AA5B46E7AF78053167FE343B8F814A784218F8 \
+  6A8F9C266528E25AEB1D7731C2371D91CB716EA7 \
+  9EDAFF80E080659604F4A76B2EBB056FD847F8A7 \
+  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
+  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
+  C388F6961FB972A95678E327F62711DBDCA8AE56 \
+  ; do \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
+
+ENV BITCOIN_VERSION=28.0
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN gpg --verify SHA256SUMS.asc SHA256SUMS
+RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
+RUN tar -xzf *.tar.gz
+
+WORKDIR /bitcoin-${BITCOIN_VERSION}
+
+RUN ./autogen.sh
+RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+  --prefix=${BITCOIN_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-sqlite=yes \
+  --with-daemon
+RUN make -j4
+RUN make install
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
+
+# Build stage for compiled artifacts
+FROM alpine
+
+ARG UID=100
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add \
+  boost-filesystem \
+  boost-system \
+  boost-thread \
+  libevent \
+  libzmq \
+  shadow \
+  sqlite-dev \
+  su-exec
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=28.0
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+
+COPY --from=bitcoin-core /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/28/alpine/docker-entrypoint.sh
+++ b/28/alpine/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec su-exec bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/28/docker-entrypoint.sh
+++ b/28/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec gosu bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ A bitcoin-core docker image with support for the following platforms:
 
 ## Tags
 
-- `24.0.1`, `24`, `latest` ([24/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/Dockerfile)) [**multi-arch**]
+- `28.0`, `28`, `latest` ([28/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/28/Dockerfile)) [**multi-arch**]
+- `28.0-alpine`, `28-alpine` ([28/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/28/alpine/Dockerfile))
+
+- `24.0.1`, `24` ([24/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/Dockerfile)) [**multi-arch**]
 - `24.0.1-alpine`, `24-alpine` ([24/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/24/alpine/Dockerfile))
 
 - `23.0`, `23` ([23/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/23/Dockerfile)) [**multi-arch**]


### PR DESCRIPTION
## Summary

- Adds `28/Dockerfile` (Debian-based, prebuilt binaries) for Bitcoin Core 28.0
- Adds `28/alpine/Dockerfile` (Alpine-based, built from source) for Bitcoin Core 28.0
- Updates `README.md` to reflect `28.0` as `latest`

## Changes vs 24.0.1

- Updated GPG signing keys to match the 28.0 release signers
- Removed `--with-libs` configure flag (libbitcoinconsensus was removed in 28.0)
- Removed `strip libbitcoinconsensus.*` lines in Alpine Dockerfile
- Removed `sed compat.h` patch (fixed upstream in 28.0)

## Test plan

- [ ] Build Debian image: `docker build -t bitcoin-core:28.0 ./28`
- [ ] Build Alpine image: `docker build -t bitcoin-core:28.0-alpine ./28/alpine`
- [ ] Verify `bitcoind -version` outputs `Bitcoin Core version v28.0`
- [ ] Test basic RPC functionality in regtest mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)